### PR TITLE
 Add `onlyNumber` property and fix paste event problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Result:
 | inputColor | String | No | '#42b983' | Color of the border bottom wen the input is filled |
 | fontColor | String | No | '#42b983' | Color of the individual Characters |
 | allowPaste | Boolean | No | true | Allow the user to paste values into the input |
+| onlyNumber | Boolean | No | false | Only allow number input |
 
 ## License
 

--- a/src/components/VueFakeInput.vue
+++ b/src/components/VueFakeInput.vue
@@ -12,6 +12,7 @@
         width: fkWidth,
       }"
       v-model="inputValues[index]"
+      @keydown="handleKeydown"
       @keyup="handleInputFocus(index)"
       @paste.prevent="handlePastedValues"
       @input="returnFullString()"
@@ -51,6 +52,11 @@ export default {
       default: true,
       required: false,
     },
+    onlyNumber: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
 
   data() {
@@ -72,6 +78,25 @@ export default {
   },
 
   methods: {
+    handleKeydown(event) {
+      if (!this.onlyNumber) {
+        return;
+      }
+      const key = event.charCode || event.keyCode || 0;
+      if (
+        !(
+          key === 8
+          || key === 46
+          || key === 86
+          || key === 91
+          || (key >= 48 && key <= 57)
+          || (key >= 96 && key <= 105)
+        )
+      ) {
+        event.preventDefault();
+      }
+    },
+
     generateInputId(index) {
       return `fk_${index + 1}`;
     },
@@ -96,14 +121,23 @@ export default {
       if (this.allowPaste) {
         const pastedValue = event.clipboardData.getData('text/plain');
         const splitValues = pastedValue.split('');
-        const _this = this;
+        let canPaste = true;
 
-        for (let i = 0; i < this.length; i++) {
-          _this.updateInputValue(i, splitValues[i]);
+        if (this.onlyNumber) {
+          const regx = new RegExp(`^\\d{${this.length}}$`);
+          canPaste = regx.test(pastedValue);
         }
 
-        const [lastInput] = this.$refs[`fk_${this.length}`];
-        lastInput.focus();
+        if (canPaste) {
+          for (let i = 0; i < this.length; i++) {
+            this.updateInputValue(i, splitValues[i]);
+          }
+
+          const [lastInput] = this.$refs[`fk_${this.length}`];
+          lastInput.focus();
+
+          this.returnFullString();
+        }
       }
     },
 

--- a/tests/unit/components/VueFakeInput.spec.js
+++ b/tests/unit/components/VueFakeInput.spec.js
@@ -62,4 +62,24 @@ describe('VueFakeInput.vue', () => {
 
     expect(methods.handleInputFocus).toHaveBeenCalledWith(0);
   });
+
+  it('call handleKeydown on keydown event', () => {
+    const methods = {
+      handleKeydown: jest.fn(),
+    };
+
+    const wrapper = shallowMount(VueFakeInput, {
+      propsData: {
+        length: 3,
+      },
+      methods,
+      attachToDocument: true,
+    });
+
+    wrapper.find('input#fk_1').trigger('keydown', {
+      key: '1',
+    });
+
+    expect(methods.handleKeydown).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
There are two updates:
1. Add `onlyNumber` property: Only allow number input.
2. Fix the paste event: After pasting value the `v-model` outside does not change.

BTW, this repo is awesome:)