### PR TITLE
Fix v-model when user pastes content from clipboard

### DIFF
--- a/src/components/VueFakeInput.vue
+++ b/src/components/VueFakeInput.vue
@@ -13,7 +13,7 @@
       }"
       v-model="inputValues[index]"
       @keyup="handleInputFocus(index)"
-      @paste.prevent="handlePastedValues"
+      @paste="handlePastedValues"
       @input="returnFullString()"
       contenteditable="true"
       :key="index"


### PR DESCRIPTION
This 'prevent' on @paste cancels the default behaviour of the paste event (i.e. pasting the contents of the clipboard into the input element). When the user pastes the content into the field, using a keyboard shortcut or context menu, it did not update the v-model.